### PR TITLE
fix buggo:  `webcam_id` -> `cam_id`

### DIFF
--- a/fast_camera_capture/experiments/imshow_tester.py
+++ b/fast_camera_capture/experiments/imshow_tester.py
@@ -9,7 +9,7 @@ async def imshow_testing():
     cams = detect_cameras()
     cvcams = []
     for info in cams.cameras_found_list:
-        c = Camera(CamArgs(webcam_id=info))
+        c = Camera(CamArgs(cam_id=info))
         c.connect()
         cvcams.append(c)
 


### PR DESCRIPTION
the `CamArgs` model has no attribute for `webcam_id` so this was making it open 5 windows for camera `0` (b/c I have 5 cameras attached to my computer)